### PR TITLE
WIP; Traits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,14 @@ homepage = "https://github.com/discordapp/itsdangerous-rs"
 documentation = "https://docs.rs/itsdangerous"
 description = "Rust port of the popular itsdangerous python library for signing strings and sending them over untrusted channels."
 
+[features]
+serializer = ["serde", "serde_json"]
+
 [dependencies]
 hmac = "0.7.0"
 sha-1 = "0.8.1"
 base64 = "0.10.1"
 generic-array = "0.12.0"
 typenum = "1.10.0"
-serde = "1.0"
-serde_json = "1.0"
+serde = { version = "1.0", optional = true }
+serde_json = { version = "1.0", optional = true }

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ not been tampered with.
 
 ## Basic Usage
 
-Add this to your `Cargo.toml`: 
+Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
@@ -23,15 +23,15 @@ itsdangerous = "0.1"
 Next, get to signing some dangerous strings:
 
 ```rust
-use itsdangerous::default_builder;
+use itsdangerous::{default_builder, Signer};
 
 fn main() {
     // Create a signer using the default builder, and an arbitrary secret key.
     let signer = default_builder("secret key").build();
-    
+
     // Sign an arbitrary string, and send it somewhere dangerous.
     let signed = signer.sign("hello world!");
-    
+
     // Unsign the string and validate that it hasn't been tampered with.
     let unsigned = signer.unsign(&signed).expect("Signature was not valid");
     assert_eq!(unsigned, "hello world!");

--- a/src/base64.rs
+++ b/src/base64.rs
@@ -85,6 +85,7 @@ where
 
 /// Decodes a base64 encoded string from `URLSafeBase64Encode` to a sized GenericArray.
 #[inline(always)]
+#[allow(dead_code)]
 pub(crate) fn decode_str<T>(input: &T) -> Result<Vec<u8>, DecodeError>
 where
     T: ?Sized + AsRef<[u8]>,
@@ -113,9 +114,9 @@ pub struct Base64SizedEncoder<N>(N);
 /// Implementation of the `Base64Sized` trait. This does the actual computation.
 ///
 /// A simple example is as follows:
-/// ```rust
-/// use itsdangerous::base64::{Base64Sized, Base64SizedEncoder};
-/// use hmac::digest::generic_array::*;
+/// ```rust,compile_fail
+/// use crate::base64::{Base64Sized, Base64SizedEncoder};
+/// use generic_array::*;
 ///
 /// let arr = arr![u8; 1, 2, 3];
 /// let result = Base64SizedEncoder::encode(arr);

--- a/src/base64.rs
+++ b/src/base64.rs
@@ -13,8 +13,8 @@ static BASE64_ALPHABET: &'static str =
 /// A trait that allows a type to be safely encoded as a url-safe
 /// basea64 string.
 pub trait URLSafeBase64Encode: Sized {
+    #[cfg(test)]
     fn base64_encode(self) -> String {
-        // XX: This is not optimal, but we are going to kill this func soon.
         let mut target = String::new();
         self.base64_encode_str(&mut target);
         target

--- a/src/base64.rs
+++ b/src/base64.rs
@@ -25,6 +25,7 @@ pub trait URLSafeBase64Encode: Sized {
 
 /// Encodes a string as url safe base64.
 #[inline(always)]
+#[allow(dead_code)]
 pub(crate) fn encode<T>(input: &T) -> String
 where
     T: ?Sized + AsRef<[u8]>,
@@ -34,6 +35,7 @@ where
 
 /// Encodes a string as url safe base64.
 #[inline(always)]
+#[allow(dead_code)]
 pub(crate) fn encode_slice<T>(input: &T, target: &mut [u8]) -> usize
 where
     T: ?Sized + AsRef<[u8]>,

--- a/src/error.rs
+++ b/src/error.rs
@@ -88,7 +88,7 @@ impl<'a> error::Error for BadSignature<'a> {
         }
     }
 
-    fn cause(&self) -> Option<&error::Error> {
+    fn cause(&self) -> Option<&dyn error::Error> {
         None
     }
 }
@@ -132,7 +132,7 @@ impl<'a> error::Error for BadTimedSignature<'a> {
         }
     }
 
-    fn cause(&self) -> Option<&error::Error> {
+    fn cause(&self) -> Option<&dyn error::Error> {
         None
     }
 }
@@ -168,7 +168,7 @@ impl error::Error for InvalidSeperator {
         "invalid seperator"
     }
 
-    fn cause(&self) -> Option<&error::Error> {
+    fn cause(&self) -> Option<&dyn error::Error> {
         None
     }
 }
@@ -184,7 +184,7 @@ impl error::Error for SeperatorNotFound {
         "seperator not foundr"
     }
 
-    fn cause(&self) -> Option<&error::Error> {
+    fn cause(&self) -> Option<&dyn error::Error> {
         None
     }
 }
@@ -230,7 +230,7 @@ impl<T> error::Error for TimestampExpired<T> {
         "timestamp expired"
     }
 
-    fn cause(&self) -> Option<&error::Error> {
+    fn cause(&self) -> Option<&dyn error::Error> {
         None
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,14 +1,15 @@
-use std::error;
-use std::fmt;
 use std::time::{Duration, SystemTime};
+use std::{error, fmt, str};
 
 use crate::base64;
 use crate::Seperator;
 
 #[derive(Debug)]
 pub enum PayloadError {
+    #[cfg(feature = "serializer")]
     Serde(serde_json::Error),
     Base64(base64::DecodeError),
+    Utf8Error(str::Utf8Error),
 }
 
 #[derive(Debug)]
@@ -241,8 +242,16 @@ impl From<base64::DecodeError> for PayloadError {
     }
 }
 
+#[cfg(feature = "serializer")]
 impl From<serde_json::Error> for PayloadError {
     fn from(error: serde_json::Error) -> Self {
         PayloadError::Serde(error)
+    }
+}
+
+#[cfg(feature = "serializer")]
+impl From<str::Utf8Error> for PayloadError {
+    fn from(error: str::Utf8Error) -> Self {
+        PayloadError::Utf8Error(error)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,10 +41,11 @@ pub mod key_derivation;
 pub mod seperator;
 pub mod signer;
 pub mod timed;
-// TODO: Feature flag.
-pub mod serde_serializer;
 mod timestamp;
 pub mod traits;
+
+#[cfg(feature = "serializer")]
+pub mod serde_serializer;
 
 pub use error::{
     BadSignature, BadTimedSignature, InvalidSeperator, PayloadError, TimestampExpired,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,15 +34,16 @@
 // TODO: One day un-comment this.
 // #![warn(missing_docs)]
 
-pub mod algorithm;
-pub mod base64;
-pub mod error;
-pub mod key_derivation;
-pub mod seperator;
-pub mod signer;
-pub mod timed;
+mod base64;
+mod error;
+mod seperator;
+mod signer;
+mod timed;
 mod timestamp;
-pub mod traits;
+mod traits;
+
+pub mod algorithm;
+pub mod key_derivation;
 
 #[cfg(feature = "serializer")]
 pub mod serde_serializer;
@@ -53,4 +54,4 @@ pub use error::{
 pub use seperator::Seperator;
 pub use signer::{default_builder, SignerBuilder};
 pub use timed::UnsignedValue;
-pub use traits::{GetSigner, Signer, TimestampSigner};
+pub use traits::{Signer, TimestampSigner};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@
 //! ## Basic Example
 //! ```rust
 //! use std::time::Duration;
-//! use itsdangerous::default_builder;
+//! use itsdangerous::{default_builder, Signer};
 //!
 //! // Create a signer using the default builder, and an arbitrary secret key.
 //! let signer = default_builder("secret key").build();
@@ -44,10 +44,12 @@ pub mod timed;
 // TODO: Feature flag.
 pub mod serde_serializer;
 mod timestamp;
+pub mod traits;
 
 pub use error::{
     BadSignature, BadTimedSignature, InvalidSeperator, PayloadError, TimestampExpired,
 };
 pub use seperator::Seperator;
-pub use signer::{default_builder, Signer, SignerBuilder};
-pub use timed::TimestampSigner;
+pub use signer::{default_builder, SignerBuilder};
+pub use timed::UnsignedValue;
+pub use traits::{GetSigner, Signer, TimestampSigner};

--- a/src/serde_serializer.rs
+++ b/src/serde_serializer.rs
@@ -38,16 +38,7 @@ impl Encoding for URLSafeEncoding {
     fn decode<'a>(&self, encoded_input: String) -> Result<String, PayloadError> {
         // TODO: Handle decompression from... you know... python land.
         let decoded = base64::decode_str(&encoded_input)?;
-        String::from_utf8(decoded)
-            .map_err(|e| {
-                let err = e.utf8_error();
-                let bytes = e.as_bytes();
-                PayloadError::Base64(base64::DecodeError::InvalidByte(
-                    err.valid_up_to(),
-                    bytes[err.valid_up_to()],
-                ))
-            })
-            .map(|e| e.into())
+        Ok(String::from_utf8(decoded).map_err(|e| e.utf8_error())?)
     }
 }
 

--- a/src/signer.rs
+++ b/src/signer.rs
@@ -5,10 +5,12 @@ use generic_array::{ArrayLength, GenericArray};
 use hmac::digest::{BlockInput, FixedOutput, Input, Reset};
 use typenum::Unsigned;
 
-use crate::algorithm::{self, Signature};
+use crate::algorithm::{self, Signature, Signer as AlgorithmSigner};
 use crate::base64::{self, Base64Sized, Base64SizedEncoder, URLSafeBase64Encode};
 use crate::key_derivation;
+use crate::timed::TimestampSignerImpl;
 use crate::{BadSignature, Seperator, TimestampSigner};
+use crate::{GetSigner, Signer};
 
 static DEFAULT_SALT: Cow<'static, str> = Cow::Borrowed("itsdangerous.Signer");
 
@@ -65,10 +67,10 @@ where
     /// Builds a Signer using the configuration specified in this builder.
     pub fn build(
         self,
-    ) -> Signer<Algorithm, Digest::OutputSize, Base64SizedEncoder<Algorithm::OutputSize>> {
+    ) -> SignerImpl<Algorithm, Digest::OutputSize, Base64SizedEncoder<Algorithm::OutputSize>> {
         let derived_key = KeyDerivation::derive_key::<Digest>(&self.secret_key, &self.salt);
 
-        Signer {
+        SignerImpl {
             derived_key,
             seperator: self.seperator,
             _phantom: PhantomData,
@@ -85,7 +87,7 @@ where
 ///
 /// # Basic Usage
 /// ```rust
-/// use itsdangerous::default_builder;
+/// use itsdangerous::{default_builder, Signer};
 ///
 /// // Create a signer using the default builder, and an arbitrary secret key.
 /// let signer = default_builder("secret key").build();
@@ -97,7 +99,7 @@ where
 /// let unsigned = signer.unsign(&signed).expect("Signature was not valid");
 /// assert_eq!(unsigned, "hello world!");
 /// ```
-pub struct Signer<Algorithm, DerivedKeySize, SignatureEncoder>
+pub struct SignerImpl<Algorithm, DerivedKeySize, SignatureEncoder>
 where
     DerivedKeySize: ArrayLength<u8>,
 {
@@ -107,73 +109,22 @@ where
 }
 
 impl<Algorithm, DerivedKeySize, SignatureEncoder>
-    Signer<Algorithm, DerivedKeySize, SignatureEncoder>
+    SignerImpl<Algorithm, DerivedKeySize, SignatureEncoder>
 where
     Algorithm: algorithm::SigningAlgorithm,
     DerivedKeySize: ArrayLength<u8>,
     SignatureEncoder: Base64Sized,
 {
-    /// Signs the given string.
-    #[inline(always)]
-    pub fn sign<S: AsRef<str>>(&self, value: S) -> String {
-        let value = value.as_ref();
-        // Pre-allocate a string with the correct size (for maximum speeds.)
-        // This (albeit a bit artisnal approach) is much faster than using `format!(...)`.
-        let mut output =
-            String::with_capacity(value.len() + 1 + SignatureEncoder::OutputSize::USIZE);
-
-        output.push_str(value);
-        output.push(self.seperator().0);
-        self.get_signature(value.as_bytes())
-            .base64_encode_str(&mut output);
-
-        output
-    }
-
-    /// Unsigns the given string. The logical inverse of [`sign`].
-    ///
-    /// # Remarks
-    ///
-    /// This method performs zero copies or heap allocations and returns a reference to a slice
-    /// of the provided `value`, If you need a copy, consider doing `unsign(..).to_owned()`
-    /// to convert the [`&str`] to a [`String`].
-    ///
-    /// [`&str`]: std::str
-    /// [`sign`]: Signer::sign
-    #[inline(always)]
-    pub fn unsign<'a>(&'a self, value: &'a str) -> Result<&'a str, BadSignature<'a>> {
-        let (value, signature) = self.seperator.split(&value)?;
-        if self.verify_encoded_signature(value.as_bytes(), signature.as_bytes()) {
-            Ok(value)
-        } else {
-            Err(BadSignature::SignatureMismatch { signature, value })
-        }
-    }
-
     /// Converts this [`Signer`] into a [`TimestampSigner`], giving it the ability
     /// to do signing with timestamps!
-    pub fn into_timestamp_signer(
-        self,
-    ) -> TimestampSigner<Algorithm, DerivedKeySize, SignatureEncoder> {
-        TimestampSigner::with_signer(self)
+    pub fn into_timestamp_signer(self) -> impl TimestampSigner {
+        TimestampSignerImpl::with_signer(self)
     }
 
     /// Gets the signature for a given value.
     #[inline(always)]
     pub(crate) fn get_signature(&self, value: &[u8]) -> Signature<Algorithm::OutputSize> {
         Algorithm::get_signature(self.derived_key.as_slice(), value)
-    }
-
-    /// Gets a signer that can produce a signature for a given value.
-    #[inline(always)]
-    pub(crate) fn get_signer(&self) -> Algorithm::Signer {
-        Algorithm::get_signer(self.derived_key.as_slice())
-    }
-
-    /// Gets the seperator that this signer is using.
-    #[inline(always)]
-    pub(crate) fn seperator(&self) -> Seperator {
-        self.seperator
     }
 
     /// Given a base64-encoded signature, attempt to decode it and convert it
@@ -191,16 +142,6 @@ where
             .into())
     }
 
-    /// Given a base-64 encoded signature, attempt to verify whether or not
-    /// it is valid for the given `value`.
-    #[inline(always)]
-    pub(crate) fn verify_encoded_signature(&self, value: &[u8], encoded_signature: &[u8]) -> bool {
-        match self.decode_signature(encoded_signature) {
-            Ok(sig) => self.verify_signature(value, sig),
-            Err(_) => false,
-        }
-    }
-
     /// Given a signature, attempt to verify whether or not it is valid
     /// for the given `value`.
     #[inline(always)]
@@ -214,9 +155,78 @@ where
     }
 }
 
+impl<Algorithm, DerivedKeySize, SignatureEncoder> Signer
+    for SignerImpl<Algorithm, DerivedKeySize, SignatureEncoder>
+where
+    Algorithm: algorithm::SigningAlgorithm,
+    DerivedKeySize: ArrayLength<u8>,
+    SignatureEncoder: Base64Sized,
+{
+    fn signature_output_size(&self) -> usize {
+        SignatureEncoder::OutputSize::USIZE
+    }
+
+    #[inline(always)]
+    fn verify_encoded_signature(&self, value: &[u8], encoded_signature: &[u8]) -> bool {
+        match self.decode_signature(encoded_signature) {
+            Ok(sig) => self.verify_signature(value, sig),
+            Err(_) => false,
+        }
+    }
+
+    #[inline(always)]
+    fn seperator(&self) -> Seperator {
+        self.seperator
+    }
+
+    #[inline(always)]
+    fn sign<S: AsRef<str>>(&self, value: S) -> String {
+        let value = value.as_ref();
+        // Pre-allocate a string with the correct size (for maximum speeds.)
+        // This (albeit a bit artisnal approach) is much faster than using `format!(...)`.
+        let mut output =
+            String::with_capacity(value.len() + 1 + SignatureEncoder::OutputSize::USIZE);
+
+        output.push_str(value);
+        output.push(self.seperator.0);
+        self.get_signature(value.as_bytes())
+            .base64_encode_str(&mut output);
+
+        output
+    }
+
+    #[inline(always)]
+    fn unsign<'a>(&'a self, value: &'a str) -> Result<&'a str, BadSignature<'a>> {
+        let (value, signature) = self.seperator.split(&value)?;
+        if self.verify_encoded_signature(value.as_bytes(), signature.as_bytes()) {
+            Ok(value)
+        } else {
+            Err(BadSignature::SignatureMismatch { signature, value })
+        }
+    }
+}
+
+impl<Algorithm, DerivedKeySize, SignatureEncoder> GetSigner
+    for SignerImpl<Algorithm, DerivedKeySize, SignatureEncoder>
+where
+    Algorithm: algorithm::SigningAlgorithm,
+    DerivedKeySize: ArrayLength<u8>,
+    SignatureEncoder: Base64Sized,
+{
+    type OutputSize = Algorithm::OutputSize;
+    type Signer = Algorithm::Signer;
+
+    /// Gets the signature for a given value.
+    #[inline(always)]
+    fn get_signer(&self) -> Self::Signer {
+        Self::Signer::new(self.derived_key.as_slice())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::Signer;
     // extern crate test;
     // use test::Bencher;
 

--- a/src/signer.rs
+++ b/src/signer.rs
@@ -78,27 +78,6 @@ where
     }
 }
 
-/// This struct can sign and unsign bytes, validating the signature provided.
-///
-/// A salt can be used to namespace the hash, so that a signed string is only
-/// valid for a given namespace. Leaving this at the default value or re-using a salt value
-/// across different parts of your application where the same signed value in one part can
-/// mean something different in another part is a security risk.
-///
-/// # Basic Usage
-/// ```rust
-/// use itsdangerous::{default_builder, Signer};
-///
-/// // Create a signer using the default builder, and an arbitrary secret key.
-/// let signer = default_builder("secret key").build();
-///
-/// // Sign an arbitrary string.
-/// let signed = signer.sign("hello world!");
-///
-/// // Unsign the string and validate whether or not its expired.
-/// let unsigned = signer.unsign(&signed).expect("Signature was not valid");
-/// assert_eq!(unsigned, "hello world!");
-/// ```
 pub struct SignerImpl<Algorithm, DerivedKeySize, SignatureEncoder>
 where
     DerivedKeySize: ArrayLength<u8>,
@@ -119,12 +98,6 @@ where
     /// to do signing with timestamps!
     pub fn into_timestamp_signer(self) -> impl TimestampSigner {
         TimestampSignerImpl::with_signer(self)
-    }
-
-    /// Gets the signature for a given value.
-    #[inline(always)]
-    pub(crate) fn get_signature(&self, value: &[u8]) -> Signature<Algorithm::OutputSize> {
-        Algorithm::get_signature(self.derived_key.as_slice(), value)
     }
 
     /// Given a base64-encoded signature, attempt to decode it and convert it

--- a/src/timed.rs
+++ b/src/timed.rs
@@ -6,27 +6,6 @@ use crate::error::BadTimedSignature;
 use crate::timestamp;
 use crate::{GetSigner, Signer, TimestampSigner};
 
-/// A TimestampSigner wraps an inner Signer, giving it the ability to dish
-/// out signatures with timestamps.
-///
-/// # Basic Usage
-/// ```rust
-/// use std::time::Duration;
-/// use itsdangerous::{default_builder, TimestampSigner};
-///
-/// // Create a signer using the default builder, and an arbitrary secret key.
-/// let signer = default_builder("secret key").build().into_timestamp_signer();
-///
-/// // Sign an arbitrary string.
-/// let signed = signer.sign("hello world!");
-///
-/// // Unsign the string and validate whether or not its expired.
-/// let unsigned = signer.unsign(&signed).expect("Signature was not valid");
-/// let value = unsigned
-///     .value_if_not_expired(Duration::from_secs(60))
-///     .expect("Signature was expired");
-/// assert_eq!(value, "hello world!");
-/// ```
 pub struct TimestampSignerImpl<TSigner>(TSigner);
 
 impl<TSigner> TimestampSignerImpl<TSigner>

--- a/src/timed.rs
+++ b/src/timed.rs
@@ -4,7 +4,8 @@ use crate::algorithm::Signer as AlgorithmSigner;
 use crate::base64::URLSafeBase64Encode;
 use crate::error::BadTimedSignature;
 use crate::timestamp;
-use crate::{GetSigner, Signer, TimestampSigner};
+use crate::traits::GetSigner;
+use crate::{Signer, TimestampSigner};
 
 pub struct TimestampSignerImpl<TSigner>(TSigner);
 
@@ -152,7 +153,7 @@ mod tests {
     // extern crate test;
     // use test::Bencher;
 
-    use crate::{default_builder, TimestampSigner};
+    use crate::{default_builder, Signer, TimestampSigner};
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
     #[test]

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -29,6 +29,8 @@ use crate::{BadTimedSignature, Seperator, UnsignedValue};
 /// assert_eq!(unsigned, "hello world!");
 /// ```
 pub trait Signer {
+    type TimestampSigner: TimestampSigner;
+
     /// Signs the given string.
     fn sign<S: AsRef<str>>(&self, value: S) -> String;
 
@@ -53,6 +55,10 @@ pub trait Signer {
     /// Gets the output size in bytes of the base-64 encoded signature part that this
     /// signer will emit.
     fn signature_output_size(&self) -> usize;
+
+    /// Converts this [`Signer`] into a [`TimestampSigner`], giving it the ability
+    /// to do signing with timestamps!
+    fn into_timestamp_signer(self) -> Self::TimestampSigner;
 }
 
 pub trait GetSigner {
@@ -74,7 +80,7 @@ pub trait GetSigner {
 /// # Basic Usage
 /// ```rust
 /// use std::time::Duration;
-/// use itsdangerous::{default_builder, TimestampSigner};
+/// use itsdangerous::{default_builder, Signer, TimestampSigner};
 ///
 /// // Create a signer using the default builder, and an arbitrary secret key.
 /// let signer = default_builder("secret key").build().into_timestamp_signer();

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,0 +1,88 @@
+use std::time::SystemTime;
+
+use generic_array::ArrayLength;
+use typenum::Unsigned;
+
+use crate::algorithm::{Signature, Signer as AlgorithmSigner};
+use crate::error::BadSignature;
+use crate::{BadTimedSignature, Seperator, UnsignedValue};
+
+pub trait Signer {
+    /// Signs the given string.
+    fn sign<S: AsRef<str>>(&self, value: S) -> String;
+
+    /// Unsigns the given string. The logical inverse of [`sign`].
+    ///
+    /// # Remarks
+    ///
+    /// This method performs zero copies or heap allocations and returns a reference to a slice
+    /// of the provided `value`, If you need a copy, consider doing `unsign(..).to_owned()`
+    /// to convert the [`&str`] to a [`String`].
+    ///
+    /// [`&str`]: std::str
+    /// [`sign`]: Signer::sign
+    fn unsign<'a>(&'a self, value: &'a str) -> Result<&'a str, BadSignature<'a>>;
+
+    fn seperator(&self) -> Seperator;
+
+    /// Given a base-64 encoded signature, attempt to verify whether or not
+    /// it is valid for the given `value`.
+    fn verify_encoded_signature(&self, value: &[u8], encoded_signature: &[u8]) -> bool;
+
+    /// Gets the output size in bytes of the base-64 encoded signature part that this
+    /// signer will emit.
+    fn signature_output_size(&self) -> usize;
+}
+
+pub trait GetSigner {
+    type OutputSize: ArrayLength<u8> + Unsigned;
+    type Signer: AlgorithmSigner<OutputSize = Self::OutputSize>;
+
+    /// Returns a signer that can be used to build a signature for a given key + values.
+    fn get_signer(&self) -> Self::Signer;
+
+    /// Returns the signature for a given key + value.
+    fn get_signature(&self, value: &[u8]) -> Signature<Self::OutputSize> {
+        self.get_signer().input_chained(value).sign()
+    }
+}
+
+pub trait TimestampSigner {
+    type Signer: Signer;
+
+    fn seperator(&self) -> Seperator {
+        self.as_signer().seperator()
+    }
+
+    /// Returns a reference to the underlying [`Signer`] if you wish to use its methods.
+    ///
+    /// # Example
+    /// ```rust
+    /// use itsdangerous::{default_builder, TimestampSigner, Signer};
+    ///
+    /// let timestamp_signer = default_builder("hello world").build().into_timestamp_signer();
+    /// let signer = timestamp_signer.as_signer();
+    /// let signer = signer.sign("hello without a timestamp!");
+    /// ```
+    fn as_signer(&self) -> &Self::Signer;
+
+    /// Signs a value with an arbitrary timestamp.
+    fn sign_with_timestamp<S: AsRef<str>>(&self, value: S, timestamp: SystemTime) -> String;
+
+    /// Signs a value using the current system timestamp (as provided by [`SystemTime::now`]).
+    fn sign<S: AsRef<str>>(&self, value: S) -> String;
+
+    /// The inverse of [`sign`] / [`sign_with_timestamp`], returning an [`UnsignedValue`], which you
+    /// can grab the value, timestamp, and assert the max age of the signed value with.
+    ///
+    /// # Remarks
+    ///
+    /// This method performs zero copies or heap allocations and returns a reference to a slice
+    /// of the provided `value`, inside of the [`UnsignedValue`] that is returned. If you need a
+    /// copy, consider doing `unsigned_value.value().to_owned()` to convert the [`&str`] to a [`String`].
+    ///
+    /// [`&str`]: std::str
+    /// [`sign`]: TimestampSigner::sign
+    /// [`sign_with_timestamp`]: TimestampSigner::sign_with_timestamp
+    fn unsign<'a>(&'a self, value: &'a str) -> Result<UnsignedValue, BadTimedSignature<'a>>;
+}


### PR DESCRIPTION
Turns out it's really annoying to put a Signer/TimestampSigner into another struct. We can fix that by making the methods a trait, that way we can put the signer in a box, or just by using a nice `where T: Signer`! 