### PR TITLE
Fix for small typo

### DIFF
--- a/src/base64.rs
+++ b/src/base64.rs
@@ -11,7 +11,7 @@ static BASE64_ALPHABET: &'static str =
     "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_=";
 
 /// A trait that allows a type to be safely encoded as a url-safe
-/// basea64 string.
+/// base64 string.
 pub trait URLSafeBase64Encode: Sized {
     #[cfg(test)]
     fn base64_encode(self) -> String {


### PR DESCRIPTION
The fix corrects a small typo in the docs.