### PR TITLE
v0.4.0 - remove legacy timestamp epoch offset

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itsdangerous"
-version = "0.3.2"
+version = "0.4.0"
 authors = ["Jake <jh@discordapp.com>"]
 edition = "2018"
 include = [

--- a/src/serde_serializer.rs
+++ b/src/serde_serializer.rs
@@ -421,7 +421,7 @@ mod tests {
             .into_timestamp_signer();
         let serializer = timed_serializer_with_signer(signer, NullEncoding);
         let timestamp = UNIX_EPOCH + Duration::from_secs(1560181622);
-        let signed = "[1,2,3].D-AM9g.nHmuOEE3v5DuwHEW9noSBOvExO0";
+        let signed = "[1,2,3].XP57dg.azFnnbv1s1cilwCeXmeVlMmbqD4";
         assert_eq!(
             serializer
                 .sign_with_timestamp(&vec![1, 2, 3], timestamp)
@@ -439,7 +439,7 @@ mod tests {
             .build()
             .into_timestamp_signer();
         let timestamp = UNIX_EPOCH + Duration::from_secs(1560181622);
-        let signed = "[1,2,3].D-AM9g.nHmuOEE3v5DuwHEW9noSBOvExO0";
+        let signed = "[1,2,3].XP57dg.azFnnbv1s1cilwCeXmeVlMmbqD4";
         let unverified_value: UnverifiedTimedValue<Vec<u8>> =
             UnverifiedTimedValue::from_str(signer.separator(), NullEncoding, signed).unwrap();
         let expected = vec![1, 2, 3];

--- a/src/signer.rs
+++ b/src/signer.rs
@@ -265,7 +265,6 @@ mod tests {
         assert!(signer.unsign("w.").is_err());
         assert!(signer.unsign(".w").is_err());
     }
-
 }
 
 #[cfg(all(test, feature = "nightly"))]

--- a/src/timed.rs
+++ b/src/timed.rs
@@ -158,7 +158,7 @@ mod tests {
         let timestamp = UNIX_EPOCH + Duration::from_secs(1560181622);
         let signed = signer.sign_with_timestamp("hello world", timestamp);
 
-        assert_eq!(signed, "hello world.D-AM9g.T7AHtE1DsJn4dzUb-oeOwpWWoX8");
+        assert_eq!(signed, "hello world.XP57dg.uBK_KvrfABr48ZHk6IrBINjpqp8");
         let unsigned = signer.unsign(&signed).unwrap();
         assert_eq!(unsigned.value(), "hello world");
         assert_eq!(unsigned.timestamp(), timestamp);
@@ -186,7 +186,6 @@ mod tests {
             .value_if_not_expired(Duration::from_secs(90))
             .is_ok());
     }
-
 }
 
 #[cfg(all(test, feature = "nightly"))]


### PR DESCRIPTION
As advertised, remove the epoch offset used for compatibility with itsdangerous 0.x. Update test case golden values to reflect new timestamp.

Also fix a warning related to an ambiguous `into_iter()` call.