### PR TITLE
Add type aliases for the default signers

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,8 +55,8 @@ pub use error::{
     BadSignature, BadTimedSignature, InvalidSeparator, PayloadError, TimestampExpired,
 };
 pub use separator::Separator;
-pub use signer::{default_builder, SignerBuilder};
-pub use timed::UnsignedValue;
+pub use signer::{default_builder, DefaultSigner, SignerBuilder};
+pub use timed::{DefaultTimestampSigner, UnsignedValue};
 pub use traits::{AsSigner, IntoTimestampSigner, Signer, TimestampSigner};
 
 #[cfg(feature = "serializer")]

--- a/src/signer.rs
+++ b/src/signer.rs
@@ -3,7 +3,7 @@ use std::marker::PhantomData;
 
 use generic_array::{ArrayLength, GenericArray};
 use hmac::digest::{BlockInput, FixedOutput, Input, Reset};
-use typenum::Unsigned;
+use typenum::{UInt, UTerm, Unsigned, B0, B1};
 
 use crate::algorithm::{self, Signature, Signer as AlgorithmSigner};
 use crate::base64::{self, Base64Sized, Base64SizedEncoder, URLSafeBase64Encode};
@@ -31,9 +31,14 @@ pub fn default_builder<S: Into<Cow<'static, str>>>(
     SignerBuilder::new(secret_key)
 }
 
+type Sha1DigestArray = UInt<UInt<UInt<UInt<UInt<UTerm, B1>, B0>, B1>, B0>, B0>;
+
 /// The default signer built by the builder returned from [`default_builder`].
-pub type DefaultSigner =
-    SignerImpl<sha1::Sha1, algorithm::HMACAlgorithm<sha1::Sha1>, key_derivation::DjangoConcat>;
+pub type DefaultSigner = SignerImpl<
+    algorithm::HMACAlgorithm<sha1::Sha1>,
+    Sha1DigestArray,
+    Base64SizedEncoder<Sha1DigestArray>,
+>;
 
 impl<Digest, Algorithm, KeyDerivation> SignerBuilder<Digest, Algorithm, KeyDerivation>
 where
@@ -224,6 +229,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::DefaultSigner;
     use crate::Signer;
 
     #[test]
@@ -238,6 +244,11 @@ mod tests {
                 .unwrap(),
             "this is a test"
         );
+    }
+
+    #[test]
+    fn test_default_alias() {
+        let _: DefaultSigner = default_builder("hello").build();
     }
 
     #[test]

--- a/src/signer.rs
+++ b/src/signer.rs
@@ -31,6 +31,10 @@ pub fn default_builder<S: Into<Cow<'static, str>>>(
     SignerBuilder::new(secret_key)
 }
 
+/// The default signer built by the builder returned from [`default_builder`].
+pub type DefaultSigner =
+    SignerImpl<sha1::Sha1, algorithm::HMACAlgorithm<sha1::Sha1>, key_derivation::DjangoConcat>;
+
 impl<Digest, Algorithm, KeyDerivation> SignerBuilder<Digest, Algorithm, KeyDerivation>
 where
     Digest: Input + BlockInput + FixedOutput + Reset + Default + Clone,

--- a/src/timed.rs
+++ b/src/timed.rs
@@ -153,7 +153,7 @@ impl<'a> UnsignedValue<'a> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{default_builder, IntoTimestampSigner, TimestampSigner};
+    use crate::{default_builder, DefaultTimestampSigner, IntoTimestampSigner, TimestampSigner};
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
     #[test]
@@ -166,6 +166,11 @@ mod tests {
         let unsigned = signer.unsign(&signed).unwrap();
         assert_eq!(unsigned.value(), "hello world");
         assert_eq!(unsigned.timestamp(), timestamp);
+    }
+
+    #[test]
+    fn test_default_alias() {
+        let _: DefaultTimestampSigner = default_builder("hello").build().into_timestamp_signer();
     }
 
     #[test]

--- a/src/timed.rs
+++ b/src/timed.rs
@@ -3,11 +3,15 @@ use std::time::{Duration, SystemTime};
 use crate::algorithm::Signer as AlgorithmSigner;
 use crate::base64::URLSafeBase64Encode;
 use crate::error::BadTimedSignature;
+use crate::signer::DefaultSigner;
 use crate::timestamp;
 use crate::traits::GetSigner;
 use crate::{AsSigner, Separator, Signer, TimestampSigner};
 
 pub struct TimestampSignerImpl<TSigner>(TSigner);
+
+/// The default [`TimestampSigner`] when using [`default_builder`].
+pub type DefaultTimestampSigner = TimestampSignerImpl<DefaultSigner>;
 
 impl<TSigner> TimestampSignerImpl<TSigner>
 where


### PR DESCRIPTION
Should make using these as struct members a little more bearable in the typing department.